### PR TITLE
Use HTTPS rather than SSH for the Swift Package Dependancies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ let package = Package(
         .library(name: "SwiftDB", targets: ["SwiftDB"])
     ],
     dependencies: [
-        .package(url: "git@github.com:vmanot/Data.git", .branch("master")),
-        .package(url: "git@github.com:vmanot/Runtime.git", .branch("master")),
-        .package(url: "git@github.com:vmanot/Swallow.git", .branch("master")),
+        .package(url: "https://github.com/vmanot/Data.git", .branch("master")),
+        .package(url: "https://github.com/vmanot/Runtime.git", .branch("master")),
+        .package(url: "https://github.com/vmanot/Swallow.git", .branch("master")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Hi! Great library.

I didn't have GitHub SSH keys setup on my machine as I never had a need. I always stuck to HTTPS.

This has never really been a problem until I tried adding SwiftDB into my project. It failed when fetching the dependancies with the following error:
```
Error while fetching remote repository: git@github.com:vmanot/Runtime.git
Authentication failed because the credentials were missing. 
```

Adding my public SSH key to GitHub fixed the issue for me.

However, this may be a barrier for some newcomers. I propose simply using HTTPS for the dependancies, which GitHub does by default.

**Note:** You'll also have to update your other packages with the same change as well, as you use SSH for them as well.

Thanks! 😄 